### PR TITLE
GUC parameters are not updated after pg_ctl reload

### DIFF
--- a/pg_count_roles.c
+++ b/pg_count_roles.c
@@ -144,7 +144,7 @@ _PG_init(void)
 	 * shared_preload_libraries, for pg_count_roles_launch().
 	 */
 
-    DefineCustomIntVariable("pg_count_roles.checK_duration",
+    DefineCustomIntVariable("pg_count_roles.check_duration",
                             "Duration between each check (in seconds).",
                             NULL,
                             &pg_count_roles_check_duration,

--- a/pg_count_roles.c
+++ b/pg_count_roles.c
@@ -29,6 +29,7 @@
 #include "executor/spi.h"
 #include "fmgr.h"
 #include "lib/stringinfo.h"
+#include "tcop/utility.h"
 #include "utils/builtins.h"
 #include "utils/guc.h"
 #include "utils/snapmgr.h"
@@ -45,35 +46,13 @@ PGDLLEXPORT void pg_count_roles_main(Datum main_arg) pg_attribute_noreturn();
 static int pg_count_roles_check_duration = 10;
 static char *pg_count_roles_database = NULL;
 
-static volatile sig_atomic_t got_sigterm = false;
-static volatile sig_atomic_t got_sighup = false;
-
-static void
-pg_count_roles_sigterm(SIGNAL_ARGS)
-{
-    int save_errno = errno;
-
-    got_sigterm = true;
-    if (MyProc)
-        SetLatch(&MyProc->procLatch);
-    errno = save_errno;
-}
-
-static void
-pg_count_roles_sighup(SIGNAL_ARGS)
-{
-    got_sighup = true;
-    if (MyProc)
-        SetLatch(&MyProc->procLatch);
-}
-
 void
 pg_count_roles_main(Datum main_arg)
 {
     StringInfoData buf;
     /* Register functions for SIGTERM/SIGHUP management */
-    pqsignal(SIGHUP, pg_count_roles_sighup);
-    pqsignal(SIGTERM, pg_count_roles_sigterm);
+    pqsignal(SIGHUP, SignalHandlerForConfigReload);
+    pqsignal(SIGTERM, die);
 
     /* We're now ready to receive signals */
     BackgroundWorkerUnblockSignals();
@@ -84,11 +63,20 @@ pg_count_roles_main(Datum main_arg)
 
     /* Build the query string */
     appendStringInfo(&buf,"SELECT count(*) FROM pg_roles;");
-    while (!got_sigterm)
+    for (;;)
     {
         int ret;
         static uint32 wait_event_info = 0;
 
+		/*
+		 * In case of a SIGHUP, just reload the configuration.
+		 */
+		if (ConfigReloadPending)
+		{
+			ConfigReloadPending = false;
+			ProcessConfigFile(PGC_SIGHUP);
+		}
+        
         if (wait_event_info == 0)
             wait_event_info  = WaitEventExtensionNew("PgCountRolesMain");
         

--- a/t/001_pg_count_roles.pl
+++ b/t/001_pg_count_roles.pl
@@ -21,7 +21,7 @@ is($result, 'idle', 'dynamic bgworker has reported "PgCountRolesMain" as wait ev
 
 # Check the "query" column of pg_stat_activity
 $result = $node->safe_psql('postgres', q[SELECT query FROM pg_stat_activity WHERE wait_event = 'PgCountRolesMain';]);
-is($result, 'SELECT count(*) FROM pg_roles;', 'pg_count_roles_main appears in query columnof pg_stat_activity');
+is($result, 'SELECT count(*) FROM pg_roles;', 'pg_count_roles_main appears in query column of pg_stat_activity');
 
 # Check the wait event used by the dynamic bgworker appears in pg_wait_events
 $result = $node->safe_psql('postgres',


### PR DESCRIPTION
GUC parameter `check_duration` and `database` are not updated after `pg_ctl reload`.

Calling `ProcessConfigFile(PGC_SIGHUP)` in main loop fixes this issue.