### PR TITLE
change the context of pg_count_roles.database to PGC_POSTMASTER

### DIFF
--- a/pg_count_roles.c
+++ b/pg_count_roles.c
@@ -58,7 +58,11 @@ pg_count_roles_main(Datum main_arg)
     BackgroundWorkerUnblockSignals();
 
     /* Connect to our database */
-    BackgroundWorkerInitializeConnection(pg_count_roles_database, NULL, 0);
+    if(!pg_count_roles_database){
+        BackgroundWorkerInitializeConnection("postgres", NULL, 0);
+    }else{
+        BackgroundWorkerInitializeConnection(pg_count_roles_database, NULL, 0);
+    }
     initStringInfo(&buf);
 
     /* Build the query string */
@@ -145,18 +149,17 @@ _PG_init(void)
                             NULL,
                             NULL);
 
+    if(!process_shared_preload_libraries_in_progress)
+        return;
+        
     DefineCustomStringVariable("pg_count_roles.database",
                                 "Database to connect to.",
                                 NULL,
                                 &pg_count_roles_database,
                                 "postgres",
-                                PGC_SIGHUP,
+                                PGC_POSTMASTER,
                                 0,
                                 NULL,NULL,NULL);
-
-    if(!process_shared_preload_libraries_in_progress)
-        return;
-    
     MarkGUCPrefixReserved("pg_count_roles");
 
     /* register the worker processes */

--- a/t/001_pg_count_roles.pl
+++ b/t/001_pg_count_roles.pl
@@ -29,22 +29,14 @@ $result = $node->safe_psql('postgres',
     q[SELECT count(*) > 0 FROM pg_wait_events WHERE type = 'Extension' AND name = 'PgCountRolesMain';]);
 is($result, 't', '"PgCountRolesMain" is reported in pg_wait_events');
 
-$node->append_conf(
-    'postgresql.conf', q{
-pg_count_roles.database = 'dummydb'
-});
-$node->reload;
-my $log_offset = -s $node->logfile;
-$node->safe_psql('postgres', 'SELECT pg_count_roles_launch();');
-$node->wait_for_log(qr/database "dummydb" does not exist/,
-                    $log_offset);
+# reload check_duration
 $node->append_conf(
     'postgresql.conf', q{
 pg_count_roles.check_duration = 5
 });
 $node->reload;
 $node->wait_for_log(qr/roles in database cluster/);
-$log_offset = -s $node->logfile;
+my $log_offset = -s $node->logfile;
 $node->wait_for_log(qr/roles in database cluster/,$log_offset);
 my $start = Time::Piece->strptime(substr(slurp_file($node->logfile, $log_offset),11,12),'%T.%N');
 $log_offset = -s $node->logfile;


### PR DESCRIPTION
Since `BackgroundWorkerInitializeConnection()` (or `BackgroundWorkerInitializeConnectionByOid()`) can be called in a background worker once, the context of GUC parameter, `pg_count_roles.database`, should be `PGC_POSTMASTER`.